### PR TITLE
Adding datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+# User Defined Ignores
+
+# Ignore Everything but Data Set Readme.
+data-sets/*
+
+# exception to the rule
+!data-sets/data_sets_readme.md
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # Malware-Visualization-and-Preprocessing-Methods-for-CNNs
 Repository for Malware Visualization and Preprocessing work by Dr. Rakesh Verma and Alec Davila
+
+
+## Data Sets
+---
+Any data sets needed for this work should be placed in the data sets folder.
+
+```
+  /root/data-sets/
+```
+They will be ignored due to keeping the repository size as minimal as possible.
+
+Data Sets used in evaluation:
+
+- MalImg Dataset orignally used in "Malware Images: Visualization and Automatic Classificatio"n by Nataraj et al., [mentioned here](https://vision.ece.ucsb.edu/research/signal-processing-malware-analysis). The link is currently dead and as of August 15, 2019 this [link](https://sarvamblog.blogspot.com/2014/08/supervised-classification-with-k-fold.html) works.
+
+- Microsoft Malware Classification Challenge (BIG 2015): This is referenced in "Malware Classification with Deep Convolutional Neural Networks" by Kalash et. al.. The data set can be found from [Kaggle](https://www.kaggle.com/c/malware-classification/data)
+
+- UH-JPL INSuRE (Spring 2019) dataset. Need to update a way to acquire the dataset. 

--- a/data-sets/data_sets_readme.md
+++ b/data-sets/data_sets_readme.md
@@ -1,0 +1,17 @@
+# Data Sets
+
+
+## MalImg
+---
+The dataset contains the images of malware family names as mentioned in Tab.3 of the paper ["Malware Images: Visualization and Automatic Classification"](http://dl.acm.org/citation.cfm?id=2016908)
+If this dataset is used, the above paper must be cited.
+This dataset is not be distributed.
+
+Any questions, contact [Dr. Nataraj](lakshmanan_nataraj@umail.ucsb.edu)
+Oct. 2013
+
+Data set was obtained from [Sarvam Blog: Supervised Classification with k-fold Cross Validation on a Multi Family Malware Dataset](https://sarvamblog.blogspot.com/2014/08/supervised-classification-with-k-fold.html)
+
+## Microsoft Malware Classification Challenge (BIG 2015)
+---
+when using this dataset, please cite: [http://arxiv.org/abs/1802.10135](http://arxiv.org/abs/1802.10135)


### PR DESCRIPTION
This is just a simple merge: 

**Updates**
- Readme for project now contains information on how the data sets are set up along with info about the datasets
- There is now a directory for data sets. Contents of the directory sans the readme with credit for the data-sets that will be used in the analysis are ignored. The data sets are too large and should not be apart of the repository. 

**Future**
- Consider writing a script to obtain the data sets. Needed
    -  Download script for the Malimg data set, could just use Python
    -  Interface with Kaggle to obtain the MicrosSoft data set
    -  Some way to obtain UH-JPL dataset 
        - Need to find permanent host for this dataset or way to build from sourcing 